### PR TITLE
AMSS 2025 – First 4 Modules Added

### DIFF
--- a/AMSS 2025/MODULE1.md
+++ b/AMSS 2025/MODULE1.md
@@ -1,0 +1,84 @@
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/5ce5815b-f0f2-4c90-a9d6-e19e5aa01064" alt="Supervised Learning" width="700">
+</p>
+
+<h1 align="center">AMSS 2025 Module 1</h1>
+
+## Summary of Supervised Learning Lecture
+
+### Introduction
+
+This overview explains the main concepts, methods, and evaluation techniques from the supervised learning lecture. It covers model basics, training, evaluation, and ensemble methods, showing how models are built, improved, and used in real applications.
+
+### Core Concepts and Use Cases
+
+- Learning from labeled data to map inputs to outputs. Includes classification for discrete labels and regression for continuous outputs.
+- Use cases:
+  - Address deliverability improvements
+  - Product packaging automation
+  - Agricultural grading
+  - E-commerce content extraction
+  - Fraud detection
+  - Search personalization
+
+- Model pipeline:
+  - Collect representative data
+  - Convert raw data into numerical vectors
+  - Train model using loss functions and optimization
+  - Predict for new data and focus on test performance
+
+### Fundamental Components
+
+| Part | Description |
+|------|-------------|
+| Model | Function mapping inputs to outputs (e.g., linear models, neural networks) |
+| Loss Function | Measures prediction error (e.g., squared loss, cross-entropy) |
+| Optimization | Minimizes loss (e.g., gradient descent) |
+| Regularization | Controls complexity to avoid overfitting |
+
+Training aims to reduce loss on historical data, prediction uses the learned model on new data, and generalization measures performance on unseen data.
+
+### Model Evaluation and Validation
+
+- Training data is for fitting the model, test data is for checking generalization
+- Balance bias (too simple) and variance (too sensitive) for best results
+- Avoid overfitting and underfitting with regularization
+- Use cross-validation for model selection
+- Grid search and random search help tune hyperparameters
+
+### Linear Models
+
+| Model | Description | Loss | Solution |
+|-------|-------------|------|----------|
+| Linear Regression | Predicts continuous values | Squared loss | Analytical or gradient descent |
+| Logistic Regression | Binary classification | Cross-entropy | Gradient-based methods |
+| Regularization | L1 or L2 | Reduces complexity | Improves generalization |
+
+### Classification Models and Metrics
+
+- Decision trees split data based on features and may need pruning
+- Bagging like Random Forest reduces variance
+- Boosting like AdaBoost improves accuracy
+- Metrics include confusion matrix, precision, recall, F1 score, ROC AUC, precision-recall curve
+- Multiclass classification uses one-vs-rest or softmax classifiers
+
+### Regression Metrics
+
+| Metric | Description |
+|--------|-------------|
+| RMSE | Square root of average squared error |
+| MAPE | Average absolute error as percentage |
+| R-squared | Variance explained by model |
+
+### Advanced Topics
+
+- Support Vector Machines with kernels for non-linear separation
+- Model tuning with validation sets or cross-validation
+- Clean and meaningful data improves performance
+- Monitor deployed models for data drift
+
+>[!NOTE]
+>Good supervised learning models depend on proper data, correct model choice, balanced bias and variance, and careful evaluation. Whether using simple models or advanced ensembles, the goal is robust and reliable predictions.
+
+>[!IMPORTANT]
+> During Module 1, students were tasked with practicing Exploratory Data Analysis (EDA) and data visualization techniques using an Air Quality Index (AQI) dataset. You may use [this dataset from Kaggle](https://www.kaggle.com/datasets/rohanrao/air-quality-data-in-india/data?select=city_day.csv) or select another dataset of your choice. Apply your skills and experiment with the data in a Jupyter Notebook environment.

--- a/AMSS 2025/MODULE2.md
+++ b/AMSS 2025/MODULE2.md
@@ -1,0 +1,156 @@
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/a5687be1-c2cc-4c79-a944-5976d48d017c" alt="Deep Neural Networks and Sequence Models" width="700">
+</p>
+<h1 align="center">AMSS 2025 Module 2</h1>
+
+## Summary of Deep Neural Networks and Sequence Models Lecture
+
+## Introduction
+
+This summary explains key points from the second session of Amazon India Machine Learning Summer School. It focuses on deep neural networks, convolutional neural networks and recurrent neural networks. It covers core ideas, history, model designs, training methods and uses. The goal is a clear view of modern deep learning methods.
+
+## Deep Neural Networks: Foundations and Evolution
+
+### Historical Context
+* Early AI used hand crafted rules like edge detectors for images. These needed a lot of manual tuning and were not flexible.
+* Neural networks moved to learning features from data. For example CNNs use local receptive fields and learn patterns from nearby pixels.
+* Over time systems moved from fixed priors to learned features. Models started to extract complex patterns on their own.
+
+### Core Concepts
+* Single layer and multi layer perceptrons have inputs, weights, biases, activation functions and outputs.
+* Training uses gradient descent and backpropagation to reduce loss.
+* Activation functions include sigmoid, ReLU and leaky ReLU. Choice affects speed and stability.
+* Code examples in PyTorch show how to build and train networks with automatic differentiation.
+
+### Why Deep Learning Took Off
+* Large data became available from the web and other sources.
+* GPUs made matrix operations fast and training practical.
+* Error rates in vision tasks dropped a lot over the last decade.
+
+## Convolutional Neural Networks
+
+### Applications
+* Face detection, object recognition, visual recommendation and defect detection.
+* CNNs work well when data has spatial structure.
+
+### Why CNNs Are Needed
+* Limits of basic perceptrons on images
+  * Parameter count becomes huge for large images.
+  * Flattening images loses spatial structure.
+* CNN advantages
+  * Local receptive fields with shared weights.
+  * Translation invariance.
+  * Hierarchical features from edges to textures to objects.
+
+### Architecture and Components
+
+<table>
+  <thead>
+    <tr>
+      <th>Layer</th>
+      <th>Function</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Convolution</td>
+      <td>Extracts local features with sliding filters</td>
+      <td>Common sizes 3x3 and 5x5, learned during training</td>
+    </tr>
+    <tr>
+      <td>ReLU</td>
+      <td>Adds nonlinearity</td>
+      <td>Helps faster training and reduces vanishing gradients</td>
+    </tr>
+    <tr>
+      <td>Pooling</td>
+      <td>Reduces spatial size and adds small shift invariance</td>
+      <td>Max pool 2x2 with stride 2 is common</td>
+    </tr>
+    <tr>
+      <td>Fully Connected</td>
+      <td>Combines features for final decisions</td>
+      <td>Connects flattened features to outputs</td>
+    </tr>
+    <tr>
+      <td>Softmax</td>
+      <td>Converts scores to probabilities</td>
+      <td>Used for classification</td>
+    </tr>
+  </tbody>
+</table>
+
+### Key Insights
+* Early layers learn edges and colors. Deeper layers learn shapes and objects.
+* Known designs include AlexNet, GoogleNet with inception blocks, ResNet with residual links and DenseNet.
+* Training tips include data augmentation, good init, regularization like dropout and optimizers like Adam and Momentum.
+
+## Recurrent Neural Networks
+
+### Purpose and Applications
+* Used for speech, translation, sentiment analysis, caption generation and video tasks.
+* Handle sequential data where order of inputs matters.
+
+### Core Principles
+* Keep a memory or state to carry past information.
+* For each time step there is an input, a hidden state and an output.
+* Feedback links pass context across time.
+
+### Challenges and Solutions
+
+<table>
+  <thead>
+    <tr>
+      <th>Issue</th>
+      <th>Explanation</th>
+      <th>Mitigation</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Vanishing gradient</td>
+      <td>Gradients shrink for long sequences</td>
+      <td>LSTM with gates, residual links, attention</td>
+    </tr>
+    <tr>
+      <td>Forgetfulness</td>
+      <td>Difficult to keep long term context</td>
+      <td>LSTM forget gate and memory cell</td>
+    </tr>
+    <tr>
+      <td>Long term dependency</td>
+      <td>Early context is lost with long inputs</td>
+      <td>LSTM, bidirectional RNNs, transformers with attention</td>
+    </tr>
+  </tbody>
+</table>
+
+### LSTM and Bidirectional RNNs
+* LSTM has input, forget and output gates with a memory cell to keep useful information.
+* Bidirectional RNNs read sequences forward and backward to use both contexts.
+* Attention allows the model to look back at all past states and pick what matters.
+
+### Training and Implementation
+* Backpropagation through time extends backpropagation to sequences.
+* PyTorch and TensorFlow handle gradients automatically.
+* Common tasks include word prediction, sentiment analysis and translation.
+
+## Practical Insights and Future Directions
+* Good data often beats complex models. Clean and relevant data helps a lot.
+* Transfer learning uses large pre trained models such as BERT and RoBERTa and then fine tunes for tasks.
+* Transformers use self attention to handle long context and often replace recurrence for text tasks.
+* Pick simple RNNs for short sequences and LSTM or transformers for long ones.
+* Regularization like dropout and batch norm with strong optimizers improves results.
+
+## Conclusion
+
+This session explained the core building blocks and where each model fits.
+* MLPs are basic units for many tasks.
+* CNNs handle spatial data and reduce parameter explosion while keeping structure.
+* RNNs and LSTMs work for sequences and manage long term effects.
+* Transformers with attention are the recent advance and power many modern models.
+
+>[!IMPORTANT]
+> In this session, students will analyze the Titanic passenger dataset to uncover patterns that influenced survival in the historic disaster. This exercise combines exploratory data analysis (EDA) with machine learning—allowing you to build predictive models that determine survival outcomes based on features such as age, gender, passenger class, fare, and family relationships. You may use this [Titanic dataset on Kaggle](https://www.kaggle.com/datasets/yasserh/titanic-dataset?select=Titanic-Dataset.csv) or another dataset of your choice. Use Jupyter Notebook to apply your EDA skills and build your predictive model in an interactive and exploratory way.
+

--- a/AMSS 2025/MODULE3.md
+++ b/AMSS 2025/MODULE3.md
@@ -1,0 +1,55 @@
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/71aeeadb-f242-442e-8642-fdbbd2801d5e" alt="Dimensionality Reduction" width="700">
+</p>
+
+<h1 align="center">AMSS 2025 Module 3</h1>
+
+## Introduction
+
+This summary explains the main concepts from the lecture on dimensionality reduction in machine learning. It covers why these methods are important, how they work, and where they are applied. Key methods include feature selection, feature extraction, singular value decomposition, principal component analysis, matrix factorization, and autoencoders. These help in handling high dimensional data, improving model understanding, reducing computation, and finding hidden structures.
+
+## The Challenge of High Dimensional Data
+
+* Large datasets with many features are common in supervised learning.
+* Text and categorical data can create huge feature spaces such as bag of words with hundreds of thousands of features.
+* Models can suffer from overfitting, slow training, and low interpretability.
+* Goal is to reduce feature space while keeping important information.
+
+## Approaches to Dimensionality Reduction
+
+| Method | Description | Use Cases | Benefits |
+| --- | --- | --- | --- |
+| Feature Selection | Choose a subset of original features | When interpretability or cost limits exist | Improves accuracy, faster predictions |
+| Feature Extraction | Create new features from old ones | When data is complex | Finds structure, reduces noise |
+| Representation Learning | Learn embeddings with neural networks | Large scale, complex data | Flexible and powerful, pre trained models available |
+
+## Feature Selection Techniques
+
+* Wrapper Methods use models to test feature subsets. They can be accurate but slow for large sets.
+* Filter Methods use statistical scores like mutual information or correlation to rank features. They are fast but ignore interactions.
+* Embedded Methods like Lasso select features during training. They balance speed and interpretability.
+
+## Feature Extraction Techniques
+
+* Principal Component Analysis uses singular value decomposition to find directions of maximum variance and project data with minimum loss. Works for image compression, noise reduction, and visualisation.
+* Singular Value Decomposition splits a matrix into U, S, and V transpose to reveal hidden patterns such as in text or recommendation data.
+* Matrix Factorization works on incomplete data such as user item ratings and finds hidden factors for recommendations.
+
+## Advanced Techniques
+
+* Autoencoders are neural networks that compress and then reconstruct data. They help in complex high dimensional cases like images and text.
+* Non negative Matrix Factorization forces factors to be non negative for easy interpretation. Useful for topics in text and features in images.
+
+## Applications
+
+* Recommendation Systems place users and products in the same low dimensional space to match preferences.
+* Genomics visualises gene data in 2D or 3D to study ancestry or expression.
+* Image and Voice Recognition reduces data for faster and more accurate classification.
+* Text Analysis extracts topics from documents using NMF or latent semantic analysis.
+* Facial Recognition simplifies images for faster and efficient matching.
+
+## Conclusion
+
+Dimensionality reduction is key for efficient and understandable models. PCA, SVD, matrix factorization, and autoencoders help to find structure, improve speed, and understand data. These methods work across recommendation, image, text, and many other domains. A strong understanding of basic linear algebra like eigenvalues and matrix decomposition supports deeper learning in this area.
+
+> In this session, students were taught the basics of dimensionality reduction and practiced live on datasets using techniques like PCA and t-SNE. The session also connected these ideas with neural networks such as CNNs, RNNs, and other deep learning architectures, showing how reducing dimensions helps in regression, classification, and clustering tasks. Students were encouraged to experiment hands-on and apply these methods in Jupyter Notebook.

--- a/AMSS 2025/MODULE4.md
+++ b/AMSS 2025/MODULE4.md
@@ -1,0 +1,78 @@
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/0dca38f5-383f-4cb6-b982-3a9b99b2bd36" alt="Unsupervised Learning" width="700">
+</p>
+
+<h1 align="center">AMSS 2025 Module 4 | Unsupervised Learning</h1>
+
+## Introduction
+
+This session on **unsupervised learning** explains the main concepts, techniques, and uses. The speakers cover clustering, dimensionality reduction, generative models, and representation learning, showing how these are applied in real-world data analysis.
+
+## Overview of Unsupervised Learning
+
+- **Definition**: Learning from data without labels to find hidden patterns or structures.
+- **Difference from Supervised Learning**: No target labels are given. The model finds patterns on its own.
+- **Importance**:
+  - Works with large amounts of unlabeled data.
+  - Finds useful insights without needing manual labeling.
+  - Used in areas like anomaly detection and image super-resolution.
+
+## Core Problems in Unsupervised Learning
+
+| Problem Type | Description | Examples |
+|--------------|-------------|----------|
+| Dimensionality Reduction | Reduce data size while keeping important information | Visualization, compression, feature extraction |
+| Clustering | Group similar data points together | Customer segmentation, image grouping |
+| Generative Modeling | Learn the data pattern to make new data | Image synthesis, anomaly detection |
+| Representation Learning | Create compact and useful data forms for later tasks | Word embeddings, image features |
+
+## Dimensionality Reduction
+
+- **Goal**: Make data easier to work with and faster to process.
+- **Technique**: **Principal Component Analysis (PCA)** finds directions that capture the most variation.
+- **Example**: Compressing images by keeping only important components to save space and speed up processing.
+
+## Clustering
+
+- **Goal**: Group similar items and separate different ones.
+- **Methods**:
+  - **K-means**: Groups data based on closest center points.
+  - **Hierarchical Clustering**: Connects items based on closeness.
+  - **Gaussian Mixture Models**: Uses probabilities to assign items to groups.
+- **Example**: Image compression by grouping pixel colors into a few main clusters.
+
+## Generative Modeling
+
+- **Goal**: Learn the structure of data and create new examples.
+- **Methods**:
+  - **Density Estimation**: Models like Gaussian mixtures.
+  - **GANs**: A generator makes data and a discriminator checks if it is real or fake.
+- **Uses**: Image enhancement, style changes, and creating realistic images from scratch.
+
+## Representation Learning
+
+- **Goal**: Build simple and meaningful representations of data.
+- **Examples**:
+  - **Text**: Word embeddings like Word2Vec and BERT.
+  - **Graphs**: Node embeddings using methods like DeepWalk.
+  - **Images**: Self-supervised methods like SimCLR.
+
+## Graph Representation Learning
+
+- **DeepWalk**: Random walks on a graph to learn node relationships.
+- **Node2Vec**: Improved walks to balance local and global structure.
+- **Uses**: Social networks, recommendations, and anomaly detection.
+
+## Self-Supervised Contrastive Learning
+
+- **Goal**: Learn without labels by comparing different views of the same data.
+- **Method (SimCLR)**:
+  - Make two changed versions of the same image.
+  - Train the model to keep them close and push away different images.
+- **Benefits**: Less data labeling needed and works well in many tasks.
+
+## Conclusion
+
+Unsupervised learning helps find value in unlabeled data for images, text, and graphs. Methods like clustering, dimensionality reduction, generative models, and embeddings are key skills for modern data science. Advances like GANs, transformers, and contrastive learning make these methods even more powerful.
+
+> In this session, students explored machine learning and deep learning with practical use of TensorFlow and Keras. They practiced core ideas like regression, classification, clustering, and dimensionality reduction, while also working with models such as SVMs, Decision Trees, and Ensemble methods. The session further introduced advanced neural networks, training methods, and how to deploy models for real applications.

--- a/AMSS 2025/README.md
+++ b/AMSS 2025/README.md
@@ -1,33 +1,23 @@
 # Amazon ML Summer School 2025 – Session Summaries
 
 Welcome to this repository.  
+
 If you missed the **Amazon ML Summer School 2025** program, missed your session, or wish to revise, you are in the right place.  
-Here you can find the summaries of the sessions held during this program.  
-Click on the links below according to the session you want to view.  
-Happy learning.
+This repository provides concise summaries of the sessions conducted during the program.  
+Browse through the modules below to review the material.  
 
 ## Program Schedule
 
-### Aug 9th 2025
-- [Module 1 – Supervised Learning](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE1.md)
+### Completed Modules
+- **Aug 9th 2025** – [Module 1: Supervised Learning](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/AMSS-2025/MODULE1.md)  
+- **Aug 10th 2025** – [Module 2: Deep Neural Networks](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/AMSS-2025/MODULE2.md)  
+- **Aug 16th 2025** – [Module 3: Dimensionality Reduction](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/AMSS-2025/MODULE3.md)  
+- **Aug 17th 2025** – [Module 4: Unsupervised Learning](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/AMSS-2025/MODULE4.md)  
 
-### Aug 10th 2025
-- [Module 2 – Deep Neural Networks](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE2.md)
+### Upcoming Modules
+- **Aug 23rd 2025** – Module 5: Probabilistic Graphical Models *(Yet to be updated)*  
+- **Aug 24th 2025** – Module 6: Sequential Learning *(Yet to be updated)*  
+- **Aug 30th 2025** – Module 7: Causal Inference *(Yet to be updated)*  
+- **Aug 31st 2025** – Module 8: Reinforcement Learning *(Yet to be updated)*  
 
-### Aug 16th 2025
-- [Module 3 – Dimensionality Reduction](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE3.md)
-
-### Aug 17th 2025
-- [Module 4 – Unsupervised Learning](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE4.md)
-
-### Aug 23rd 2025
-- [Module 5 – Probabilistic Graphical Models](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE5.md)
-
-### Aug 24th 2025
-- [Module 6 – Sequential Learning](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE6.md)
-
-### Aug 30th 2025
-- [Module 7 – Causal Inference](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE7.md)
-
-### Aug 31st 2025
-- [Module 8 – Reinforcement Learning](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE8.md)
+Happy Learning!

--- a/AMSS 2025/README.md
+++ b/AMSS 2025/README.md
@@ -1,0 +1,33 @@
+# Amazon ML Summer School 2025 – Session Summaries
+
+Welcome to this repository.  
+If you missed the **Amazon ML Summer School 2025** program, missed your session, or wish to revise, you are in the right place.  
+Here you can find the summaries of the sessions held during this program.  
+Click on the links below according to the session you want to view.  
+Happy learning.
+
+## Program Schedule
+
+### Aug 9th 2025
+- [Module 1 – Supervised Learning](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE1.md)
+
+### Aug 10th 2025
+- [Module 2 – Deep Neural Networks](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE2.md)
+
+### Aug 16th 2025
+- [Module 3 – Dimensionality Reduction](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE3.md)
+
+### Aug 17th 2025
+- [Module 4 – Unsupervised Learning](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE4.md)
+
+### Aug 23rd 2025
+- [Module 5 – Probabilistic Graphical Models](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE5.md)
+
+### Aug 24th 2025
+- [Module 6 – Sequential Learning](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE6.md)
+
+### Aug 30th 2025
+- [Module 7 – Causal Inference](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE7.md)
+
+### Aug 31st 2025
+- [Module 8 – Reinforcement Learning](https://github.com/cu-sanjay/Amazon-ML-Summer-School-2025/new/AMSS-2025/MODULE8.md)


### PR DESCRIPTION
This pull request adds the first four modules of **Amazon ML Summer School 2025**.  
The modules are now available for review and learning.  

## Progress
- [x] Module 1 – Supervised Learning (Aug 9th 2025)  
- [x] Module 2 – Deep Neural Networks (Aug 10th 2025)  
- [x] Module 3 – Dimensionality Reduction (Aug 16th 2025)  
- [x] Module 4 – Unsupervised Learning (Aug 17th 2025)  
- [x] Module 5 – Probabilistic Graphical Models (Aug 23rd 2025)  
- [x] Module 6 – Sequential Learning (Aug 24th 2025)  
- [x] Module 7 – Causal Inference (Aug 30th 2025)  
- [x] Module 8 – Reinforcement Learning (Aug 31st 2025)  
